### PR TITLE
Skip address validation for estimated shipping

### DIFF
--- a/src/services/SalesTaxService.php
+++ b/src/services/SalesTaxService.php
@@ -354,7 +354,12 @@ class SalesTaxService extends Component
             Avatax::info(__FUNCTION__.'(): Address validation is disabled.');
 
             return false;
-        }
+				}
+				
+				if(!empty(Craft::$app->getRequest()->getParam('estimatedShippingAddress'))){
+					Avatax::info(__FUNCTION__.'(): Skipping address validation for estimated shipping');
+					return false;
+				}
 
         $response = $this->getValidateAddress($address);
 


### PR DESCRIPTION
When estimating shipping costs you don't have a complete shipping address, in this case it would be safe to skip address validation