### PR TITLE
Fix bug in getAddressSignature()

### DIFF
--- a/src/services/SalesTaxService.php
+++ b/src/services/SalesTaxService.php
@@ -768,6 +768,6 @@ class SalesTaxService extends Component
         $zipCode = $address->zipCode;
         $country = $this->getCountry($address);
 
-        return md5($address1.$address2.$city.$zipCode.$country);
+        return md5($address1.$address2.$city.$state.$zipCode.$country);
     }
 }


### PR DESCRIPTION
`$state` was missing from the signature, which meant that changing the state of an address that had been validated and validating it again would incorrectly use the cached result.