### PR TITLE
Only consider an address valid if coordinates are returned

### DIFF
--- a/src/services/SalesTaxService.php
+++ b/src/services/SalesTaxService.php
@@ -358,7 +358,7 @@ class SalesTaxService extends Component
 
         $response = $this->getValidateAddress($address);
 
-        if(!empty($response->validatedAddresses) || isset($response->coordinates))
+        if(!empty($response->validatedAddresses) && isset($response->coordinates))
         {
             return true;
         }


### PR DESCRIPTION
When entering an invalid ZIP code (e.g. `99999`), Avatax's address validation API responds with something like this:

```json
{
    "address": {
        "textCase": "Mixed",
        "line1": "123 Pratt St",
        "city": "Durham",
        "region": "AK",
        "country": "US",
        "postalCode": "99999"
    },
    "validatedAddresses": [
        {
            "addressType": "UnknownAddressType",
            "line1": "123 Pratt St",
            "line2": "",
            "line3": "",
            "city": "Durham",
            "region": "AK",
            "country": "US",
            "postalCode": "99999"
        }
    ],
    "resolutionQuality": "External",
    "messages": [
        {
            "summary": "Address not geocoded.",
            "details": "Address cannot be geocoded.",
            "refersTo": "Address",
            "severity": "Error",
            "source": "Avalara.AvaTax.Common"
        },
        {
            "summary": "The city could not be determined.",
            "details": "The city could not be found or determined from postal code.",
            "refersTo": "Address.City",
            "severity": "Error",
            "source": "Avalara.AvaTax.Common"
        }
    ]
}
```

...which is currently considered valid by this plugin, but I don't think it should be. I'm suggesting changing the condition that determines whether an address is valid to require an entry in `validatedAddresses` AND have `coordinates` (latitude and longitude), instead of OR.