### PR TITLE
Adds `SalesTaxService::EVENT_BEFORE_CREATE_SALES_ORDER`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- `SalesTaxService::EVENT_BEFORE_CREATE_SALES_ORDER`. [#58](https://github.com/surprisehighway/craft-avatax/issues/)
+
+
 ## 4.0.2 - 2025-03-11
 ### Fixed
 - Fixed an error that occured when attempting to recalculate the admin order. [#55](https://github.com/surprisehighway/craft-avatax/issues/55)

--- a/README.md
+++ b/README.md
@@ -382,6 +382,31 @@ This example demonstrates a potential button click handler that triggers a custo
 {% endjs %}
 
 ```
+## Events
+
+You can cancel AvaTax tax calculation for a given Commerce `Order` by listening for a cancelable event fired just before calculation begins.
+
+```php
+<?php
+
+use yii\base\Event;
+use surprisehighway\avatax\events\BeforeCreateSalesOrderEvent;
+use surprisehighway\avatax\services\SalesTaxService;
+
+Event::on(
+    SalesTaxService::class,
+    SalesTaxService::EVENT_BEFORE_CREATE_SALES_ORDER,
+    function (BeforeCreateSalesOrderEvent $event) {
+        // Example rule: skip tax calculation for carts in a specific state
+        $order = $event->order;
+        if (!order->myCustomField === true) {
+            $event->isValid = false; // Cancel AvaTax calculation for this order
+
+            $event->isHandled = true; // Optionally prevent other event handlers from overriding.
+        }
+    }
+);
+```
 
 ## AvaTax Plugin Roadmap
 

--- a/src/events/BeforeCreateSalesOrderEvent.php
+++ b/src/events/BeforeCreateSalesOrderEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace surprisehighway\avatax\events;
+
+use craft\events\CancelableEvent;
+use craft\commerce\elements\Order;
+
+/**
+ * Event triggered before creating an AvaTax sales order calculation.
+ * Handlers may set $isValid = false to cancel tax calculation for the given order.
+ */
+class BeforeCreateSalesOrderEvent extends CancelableEvent
+{
+    /**
+     * The Commerce order instance for which tax calculation is being attempted.
+     */
+    public Order $order;
+}
+
+


### PR DESCRIPTION
- #58 

Provides a PHP centric way to disable tax calculations on an order. 