### PR TITLE
Implement error handling for log file writing

### DIFF
--- a/src/services/LogService.php
+++ b/src/services/LogService.php
@@ -71,8 +71,11 @@ class LogService extends Component
 			'message' => $message,
 			'data' => $data,
 		];
-
-		FileHelper::writeToFile($this->logFile, json_encode($log).PHP_EOL, ['append' => true]);
+		try {
+			FileHelper::writeToFile($this->logFile, json_encode($log).PHP_EOL, ['append' => true]);
+		} catch (Exception $e) {
+			Craft::error($e->getMessage(), __METHOD__);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added error handling for file writing in LogService.

We have a high traffic webstore, and when we run bulk updates to the order, we get a [yii\base\ErrorException:1] Unable to acquire a lock for file "....storage/logs/avatax.log".

The change only prevents a halt to the main controller due to the lock issue.